### PR TITLE
Large refactor to address a couple issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 matt-filion
+Copyright (c) 2016 matt-filion, Ibotta
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,13 +17,7 @@ plugins:
 
 ```
 
-**2. Grant Permissions**
-I cant find a way to automate this yet. You need to run this command that gives permissions for your bucket to invoke your lambda function. If I can figure out a way to add this into the plugin I will, it annoys me this is a step.
-```
-aws lambda add-permission --function-name FUNCTION_NAME --region us-west-2 --statement-id ANY_ID --action "lambda:InvokeFunction" --principal s3.amazonaws.com --source-arn arn:aws:s3:::BUCKET_NAME --source-account YOUR_AWS_ACCOUNT_NUM
-```
-
-**3. Give your deploy permission to access the bucket.**
+**2. Give your deploy permission to access the bucket.**
 The BUCKET_NAME variable within provider.iamRoleStatements.Resource.Fn::Join needs to be replaced with the name of the bucket you want to attach your event(s) to.  If there are multiple buckets you want to attach events to add a new item for each bucket.
 
 ```serverless.yml
@@ -38,11 +32,11 @@ provider:
        Resource:
          Fn::Join:
            - ""
-           - - "arn:aws:s3:::BUCKET_NAME" 
-           - - "arn:aws:s3:::BUCKET_OTHERNAME" 
+           - - "arn:aws:s3:::BUCKET_NAME"
+           - - "arn:aws:s3:::BUCKET_OTHERNAME"
 ```
 
-**4. Attach an event to your target function.**
+**3. Attach an event to your target function.**
 Add an -existingS3 event definition under 'events' of your function declaration. The 'events' value is optional under your -existingS3 event and if omitted, it will default to a single entry for "s3:ObjectCreated:*".
 
 The rules property is optional and can contain either a prefix, suffix or both of these properties as a rule for when the event will trigger.
@@ -58,7 +52,7 @@ functions:
     events:
       - existingS3:
           bucket: BUCKET_NAME
-          events: 
+          events:
             - s3:ObjectCreated:*
           rules:
             - prefix: images/

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 'use strict';
 
-class Deploy {
+class S3Deploy {
   constructor(serverless, options) {
     this.serverless  = serverless;
     this.options     = options;
+    this.service     = serverless.service;
     this.provider    = this.serverless.getProvider('aws');
+    this.providerConfig = this.service.provider;
+    this.functionPolicies = {};
+
     this.commands    = {
       s3deploy: {
         lifecycleEvents: [
@@ -13,122 +17,172 @@ class Deploy {
       },
     };
     this.hooks = {
-      'after:s3deploy:events': this.afterDeployFunctions.bind(this)
+      'after:s3deploy:events': this.afterS3DeployFunctions.bind(this)
     };
   }
 
-  afterDeployFunctions() {
+  afterS3DeployFunctions() {
+    let funcObjs = this.service.getAllFunctions().map(name => this.service.getFunction(name));
 
-    // console.log("this.provider",this.provider);
+    //turn functions into the config objects (flattened)
+    let lambdaConfigs = funcObjs.map(obj => this.getLambdaFunctionConfigurationsFromFunction(obj))
+    .reduce((flattened, c) => flattened = flattened.concat(c), []);
 
-    const bucketNotifications = this.serverless.service.getAllFunctions()
-      .map( name => this.serverless.service.getFunction(name) )
-      /*
-       * Create a LambdaFunctionConfigurations for existingS3 configuration
-       *  on each functionObj.
-       */
-      .map( functionObj => this.getLambdaFunctionConfigurationsFromFunction(functionObj) )
-      /*
-       * Flatten the results
-       */
-      .reduce( (accumulator,current) => accumulator = accumulator.concat(current) , [])
-      /*
-       * Organize the resulting configurations so that all events for the
-       *  same bucket are together.
-       */
-      .reduce( (accumulator,current) => {
-        let bucketLambdaConfigs = accumulator.find( eventConfig => eventConfig.name === current.bucket );
-        if(!bucketLambdaConfigs) {
-          bucketLambdaConfigs = { bucket:current.bucket, configs:[] };
-          accumulator.push(bucketLambdaConfigs);
-        }
-        bucketLambdaConfigs.configs.push(current.config);
-        return accumulator;
-      }, [])
-      /*
-       * Create a bucket configuration as AWS needs it for each
-       *  bucket.
-       */
-      .map(bucketConfig=> {
-        return {
-          Bucket:bucketConfig.bucket,
-          NotificationConfiguration: {
-            LambdaFunctionConfigurations:bucketConfig.configs
+    //collate by bucket
+    let bucketNotifications = lambdaConfigs.reduce((buckets, c) => {
+      // TODO simplify this
+      //find existing array with bucket name
+      let bucketLambdaConfigs = buckets.find(existing => existing.Bucket === c.bucket);
+      //otherwise create it
+      if (!bucketLambdaConfigs) {
+        bucketLambdaConfigs = { Bucket: c.bucket, NotificationConfiguration: { LambdaFunctionConfigurations: [] } };
+        buckets.push(bucketLambdaConfigs);
+      }
+      //add config to notification
+      bucketLambdaConfigs.NotificationConfiguration.LambdaFunctionConfigurations.push(c.config);
+      return buckets;
+    }, []);
+
+    //skip empty configs
+    if (bucketNotifications.length === 0) {
+      return Promise.resolve();
+    }
+
+    //find the info plugin
+    let info = this.serverless.pluginManager.getPlugins().find(i => i.constructor.name === 'AwsInfo');
+    //use it to get deployed functions to check for things to attach to
+    return info.getStackInfo().then(() => {
+      // TODO make this a separate method
+      let results = info.gatheredData.info;
+
+      let permsPromises = [];
+      let buckets = [];
+      bucketNotifications.forEach((bucket) => {
+        //check this buckets notifications and replace the arn with the real one
+        bucket.NotificationConfiguration.LambdaFunctionConfigurations.forEach((cfg) => {
+          let deployed = results.functions.find((fn) => fn.deployedName === cfg.LambdaFunctionArn);
+          if (!deployed) {
+            throw new Error("It looks like the function has not yet beend deployed. You must use 'sls deploy' before doing 'sls s3deploy.");
           }
-        } 
-      })
+          //get the full arn!
+          let output = info.gatheredData.outputs.find((out) => out.OutputValue.indexOf(deployed.deployedName) !== -1);
+          let arn = output.OutputValue.replace(/:\d$/, ''); //unless using qualifier?
 
-    /*
-     * Don't bother doing any work if there is no configurations specified for this
-     *  plugin.
-     */
-    if(bucketNotifications.length===0) return Promise.resolve();
+          //replace placeholder ARN with final
+          cfg.LambdaFunctionArn = arn;
+          this.serverless.cli.log(`Attaching ${deployed.deployedName} to ${bucket.Bucket} ${cfg.Events}...`);
 
-    /*
-     * Lookup the ARN for each function referenced within the bucket
-     *  events.
-     */
-    return this.provider.request('CloudFormation','describeStacks',null,this.options.stage,this.options.region)
-      .then( results => !results.Stacks ? [] : results.Stacks.reduce((accumulator,current) => accumulator.concat(current.Outputs), []))
-      .then( outputs => outputs.filter(output => output && output.OutputValue) )
-      .then( outputs => {
-        bucketNotifications.forEach( notification => {
-          notification.NotificationConfiguration.LambdaFunctionConfigurations.forEach( lambdaFunctionConfiguration => {
-            const lambdaRegexp = new RegExp(`:function:${lambdaFunctionConfiguration.LambdaFunctionArn}(\:)?`);
-            const output = outputs.find( output => output.OutputValue.match(lambdaRegexp) );
-            if(!output) throw new Error("It looks like the function has not yet beend deployed. You must use 'sls deploy' before doing 'sls s3deploy.");
-            lambdaFunctionConfiguration.LambdaFunctionArn = output.OutputValue.replace(/:\d$/, '');
-          })
-        })
-      })
-      /*
-       * Attach the events to each bucket.
-       */
-      .then( () => console.log("Attaching event(s) to:",bucketNotifications.reduce( (result,bucket) => result += bucket.Bucket + ' ','')) )
-      .then( () => Promise.all( bucketNotifications.map(param => this.provider.request('S3','putBucketNotificationConfiguration', param, this.options.stage, this.options.region) ) ) )
-      .then( () => console.log("Done."))
-      .catch( error => console.log("Error attaching event(s)",error.message ? error.message : error));
-    
-  }
-  
-  getLambdaFunctionConfigurationsFromFunction(functionObj) {
-    return functionObj.events
-      .filter(event => event.existingS3)
-      .map(event => {
-        const bucketEvents = event.existingS3.events || event.existingS3.bucketEvents || ['s3:ObjectCreated:*'],
-            eventRules = event.existingS3.rules || event.existingS3.eventRules || [];
-
-        /*
-         * Hoping the ID causes overwriting of an existing configuration.
-         */
-        const returnObject = {
-          bucket: event.existingS3.bucket,
-          config: {
-            Id: 'trigger--' + functionObj.name + '--when--' + bucketEvents.join().replace(/[\.\:\*]/g,''),
-            LambdaFunctionArn: functionObj.name,
-            Events: bucketEvents
-          }
-        };
-
-        if (eventRules.length > 0) {
-          returnObject.config.Filter = {};
-          returnObject.config.Filter.Key = {};
-          returnObject.config.Filter.Key.FilterRules = [];
-        }
-
-        eventRules.forEach(rule => {
-          Object.keys(rule).forEach(key => {
-            returnObject.config.Filter.Key.FilterRules.push({
-              Name: key,
-              Value: rule[key]
-            });
-          });
+          //attach the bucket permission to the lambda
+          let permConfig = {
+            Action: "lambda:InvokeFunction",
+            FunctionName: deployed.deployedName,
+            Principal: 's3.amazonaws.com',
+            StatementId: `${deployed.deployedName}-${bucket.Bucket}`, // TODO hash the entire cfg? in case multiple
+            //Qualifier to point at alias or version
+            SourceArn: `arn:aws:s3:::${bucket.Bucket}`
+          };
+          permsPromises.push(this.lambdaPermApi(permConfig));
         });
 
-        return returnObject;
+        //attach the event notification to the bucket
+        buckets.push(bucket);
+      });
+
+      //run permsPromises before buckets
+      return Promise.all(permsPromises)
+      .then(() => Promise.all(buckets.map((b) => this.s3EventApi(b))));
+    })
+    .then(() => this.serverless.cli.log('Done.'));
+  }
+
+  getLambdaFunctionConfigurationsFromFunction(functionObj) {
+    return functionObj.events
+    .filter(event => event.existingS3)
+    .map(event => {
+      let bucketEvents = event.existingS3.events || event.existingS3.bucketEvents || ['s3:ObjectCreated:*'];
+      let eventRules = event.existingS3.rules || event.existingS3.eventRules || [];
+
+      const returnObject = {
+        bucket: event.existingS3.bucket,
+        config: {
+          Id: 'trigger-' + functionObj.name + '-when-' + bucketEvents.join().replace(/[\.\:\*]/g,''), // TODO hash the filter?
+          LambdaFunctionArn: functionObj.name,
+          Events: bucketEvents
+        }
+      };
+
+      if (eventRules.length > 0) {
+        returnObject.config.Filter = {};
+        returnObject.config.Filter.Key = {};
+        returnObject.config.Filter.Key.FilterRules = [];
+      }
+
+      eventRules.forEach(rule => {
+        Object.keys(rule).forEach(key => {
+          returnObject.config.Filter.Key.FilterRules.push({
+            Name: key,
+            Value: rule[key]
+          });
+        });
+      });
+
+      return returnObject;
     })
   }
+
+  s3EventApi(cfg) {
+    //this is read/modify/put
+    return this.provider.request('S3', 'getBucketNotificationConfiguration', { Bucket: cfg.Bucket }, this.providerConfig.stage, this.providerConfig.region)
+    .then((bucketConfig) => {
+      //find lambda with our ARN or ID, replace it or add a new one
+      cfg.NotificationConfiguration.LambdaFunctionConfigurations.forEach((ourcfg) => {
+        let currentConfigIndex = bucketConfig.LambdaFunctionConfigurations.findIndex((s3cfg) => ourcfg.LambdaFunctionArn === s3cfg.LambdaFunctionArn || ourcfg.Id === s3cfg.Id);
+        if (currentConfigIndex !== -1) {
+          //just remove it
+          bucketConfig.LambdaFunctionConfigurations.splice(currentConfigIndex, 1);
+        }
+        //push new config
+        bucketConfig.LambdaFunctionConfigurations.push(ourcfg);
+      });
+      debugger;
+      return { Bucket: cfg.Bucket, NotificationConfiguration: bucketConfig };
+    }).then((cfg) => {
+      return this.provider.request('S3', 'putBucketNotificationConfiguration', cfg, this.providerConfig.stage, this.providerConfig.region);
+    });
+  }
+
+  lambdaPermApi(cfg) {
+    //detect existing config with a read call
+    //https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#getPolicy-property
+    var existingPolicyPromise = null;
+    if (this.functionPolicies[cfg.FunctionName]) {
+      existingPolicyPromise = Promise.resolve(this.functionPolicies[cfg.FunctionName]);
+    } else {
+      existingPolicyPromise = this.provider.request('Lambda', 'getPolicy', { FunctionName: cfg.FunctionName }, this.providerConfig.stage, this.providerConfig.region)
+      .then((result) => {
+        let policy = JSON.parse(result.Policy);
+        this.functionPolicies[cfg.FunctionName] = policy;
+        return policy;
+      });
+    }
+
+    return existingPolicyPromise.then((policy) => {
+      //find our id
+      let ourStatement = policy.Statement.find((stmt) => stmt.Sid === cfg.StatementId);
+      if (ourStatement) {
+        //delete the statement before adding a new one
+        return this.provider.request('Lambda', 'removePermission', { FunctionName: cfg.FunctionName, StatementId: cfg.StatementId }, this.providerConfig.stage, this.providerConfig.region);
+      } else {
+        //just resolve
+        return Promise.resolve();
+      }
+    })
+    .then(() => {
+      //put the new policy
+      return this.provider.request('Lambda', 'addPermission', cfg, this.providerConfig.stage, this.providerConfig.region);
+    });
+  }
+
 }
 
-module.exports = Deploy;
-
+module.exports = S3Deploy;

--- a/package.json
+++ b/package.json
@@ -1,21 +1,18 @@
 {
   "name": "serverless-external-s3-event",
-  "version": "1.0.4",
-  "description": "Overcomes the CloudFormation limitation on attaching an event to an uncontrolled bucket, for Serverless.com 1.5+.",
+  "version": "1.0.5",
+  "description": "Attach Lambda events to an existing S3 bucket, for Serverless.com 1.5+.",
   "main": "index.js",
   "homepage": "https://github.com/matt-filion/serverless-external-s3-event",
-  "author":"Matt Filion <matt.filion@gmail.com>",
-  "dependencies": {
-  },
-  "devDependencies": {
-  },
+  "dependencies": {},
+  "devDependencies": {},
   "maintainers": [
     {
       "name": "Matt Filion",
       "email": "matt.filion@gmail.com"
     }
   ],
-  "files":[
+  "files": [
     "index.js",
     "README.md",
     "LICENSE",
@@ -25,16 +22,17 @@
     {
       "name": "Matt Filion",
       "email": "matt.filion@gmail.com"
+    },
+    {
+      "name": "Justin Hart",
+      "email": "npm@onyxraven.com"
     }
   ],
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/matt-filion/serverless-external-s3-event"
   },
-  "bugs" : {
+  "bugs": {
     "url": "https://github.com/matt-filion/serverless-external-s3-event/issues"
   },
   "author": {
@@ -42,7 +40,6 @@
     "email": "matt.filion@gmail.com"
   },
   "private": false,
-  "readmeFilename": "README.md",
   "licenses": [
     {
       "type": "MIT",
@@ -50,10 +47,10 @@
     }
   ],
   "keywords": [
-     "s3",
-     "event",
-     "notifications",
-     "serverless",
-     "serverless.com"
+    "s3",
+    "event",
+    "notifications",
+    "serverless",
+    "serverless.com"
   ]
 }


### PR DESCRIPTION
Summary
----------

This is a major changeset that takes the current package's starting point and enables some of the automated processes promised by this package.

I did end up doing other refactors as I went, while trying to understand all of the pieces already there.  

I hope to continue work on this package and really thank @matt-filion for the starting point.

Addresses Issues
----------

* https://github.com/matt-filion/serverless-external-s3-event/issues/10 - Attaches the appropriate Lambda Resource policy, idempotently.  It just always replaces it.
* https://github.com/matt-filion/serverless-external-s3-event/issues/6 - Handles multiple notifications against the same bucket.  The S3 notifications API is one-shot for the entire bucket

Future Work
----------

* [ ] This probably deserves 1.1 version, at least.
* [ ] Still is not a deploy hook, but I think now it certainly could be.  That'll be in a next version bump
* [ ] Removals aren't in yet, but the way forward on those should be pretty clear from the way the s3 notification is modified here.  Should be just editing the current notification list and removing the matching record.
* [ ] Doesn't address the procedure bulletpoint in the README.  That right is required for the user running the SLS command, and not for the lambda itself, so as far as I can tell it doesn't belong in the serverless.yml file - but I'm following up on that

