### PR TITLE
fix the bucket name with contain '.' and fix policy missing for lamdba

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class S3Deploy {
             Action: "lambda:InvokeFunction",
             FunctionName: deployed.deployedName,
             Principal: 's3.amazonaws.com',
-            StatementId: `${deployed.deployedName}-${bucket.Bucket}`, // TODO hash the entire cfg? in case multiple
+            StatementId: `${deployed.deployedName}-${bucket.Bucket.replace(/[\.\:\*]/g,'')}`, // TODO hash the entire cfg? in case multiple
             //Qualifier to point at alias or version
             SourceArn: `arn:aws:s3:::${bucket.Bucket}`
           };
@@ -175,6 +175,14 @@ class S3Deploy {
       } else {
         //just resolve
         return Promise.resolve();
+      }
+    })
+    .catch((err) => {
+      //this one is going to handle the issue when Policy Permission not found.
+      if(err.toString() === 'ServerlessError: The resource you requested does not exist.'){
+        return Promise.resolve();
+      } else {
+        return Promise.reject(err);
       }
     })
     .then(() => {

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ class S3Deploy {
     })
     .catch((err) => {
       //this one is going to handle the issue when Policy Permission not found.
-      if(err.toString() === 'ServerlessError: The resource you requested does not exist.'){
+      if(err.statusCode === 404 && err.toString() === 'ServerlessError: The resource you requested does not exist.'){
         return Promise.resolve();
       } else {
         return Promise.reject(err);


### PR DESCRIPTION
When the bucket name have "."
StatementId is not allow "." on it. so i apply a regular expression 
to try to ignore special char. 

Another one is handle the for the case Lamdba missing Policy information.
