### PR TITLE
default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,13 @@ class S3Deploy {
     this.providerConfig = this.service.provider;
     this.functionPolicies = {};
 
+    this.options.stage = this.options.stage
+      || (this.serverless.service.provider && this.serverless.service.provider.stage)
+      || 'dev';
+    this.options.region = this.options.region
+      || (this.serverless.service.provider && this.serverless.service.provider.region)
+      || 'us-east-1';
+
     this.commands    = {
       s3deploy: {
         lifecycleEvents: [


### PR DESCRIPTION
Without this I get the following error when running `sls s3deploy` with no params.

> It looks like the function has not yet beend deployed.
     You must use 'sls deploy' before doing 'sls s3deploy.

This is due to `getStackInfo` using `options.stage` within the name of the lambda (it'll be `undefined` otherwise).

See:
* [serverless/lib/plugins/aws/lib/validate.js](https://github.com/serverless/serverless/blob/c345e9a9bfb5dd49a13788009430e24c400243f2/lib/plugins/aws/lib/validate.js)
* [serverless/lib/plugins/aws/info/getStackInfo.js](https://github.com/serverless/serverless/blob/c345e9a9bfb5dd49a13788009430e24c400243f2/lib/plugins/aws/info/getStackInfo.js#L44)

Changes:

* Add default options