### PR TITLE
Make possible to support multiple existingS3 definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,6 @@ class S3Deploy {
     this.providerConfig = this.service.provider;
     this.functionPolicies = {};
 
-    this.options.stage = this.options.stage
-      || (this.serverless.service.provider && this.serverless.service.provider.stage)
-      || 'dev';
-    this.options.region = this.options.region
-      || (this.serverless.service.provider && this.serverless.service.provider.region)
-      || 'us-east-1';
-
     this.commands    = {
       s3deploy: {
         usage: 'Attaches lambda notification events to existing s3 buckets',
@@ -81,7 +74,7 @@ class S3Deploy {
     }
 
     
-    return this.provider.request('S3', 'listBuckets', {}, this.options.stage, this.options.region)
+    return this.provider.request('S3', 'listBuckets', {}, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`)
       .then((returnedBuckets)=>{
 
         if(!returnedBuckets.Buckets) {
@@ -150,7 +143,7 @@ class S3Deploy {
     // Check if they explicitly stopped function versioning
     if(info.serverless.service.provider.versionFunctions === false) {
       
-      return this.provider.request('Lambda', 'getFunction', {FunctionName: deployedName}, this.options.stage, this.options.region).then((functionInfo) => {
+      return this.provider.request('Lambda', 'getFunction', {FunctionName: deployedName}, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`).then((functionInfo) => {
         return functionInfo.Configuration.FunctionArn;
       });
 
@@ -290,7 +283,7 @@ class S3Deploy {
 
   s3EventApi(cfg) {
     //this is read/modify/put
-    return this.provider.request('S3', 'getBucketNotificationConfiguration', { Bucket: cfg.Bucket }, this.options.stage, this.options.region)
+    return this.provider.request('S3', 'getBucketNotificationConfiguration', { Bucket: cfg.Bucket }, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`)
     .then((bucketConfig) => {
       // This updates existing S3 notifications (or it tries to)
       var servicePrefix = "", found = false;
@@ -329,7 +322,7 @@ class S3Deploy {
       return { Bucket: cfg.Bucket, NotificationConfiguration: bucketConfig };
 
     }).then((cfg) => {
-      return this.provider.request('S3', 'putBucketNotificationConfiguration', cfg, this.options.stage, this.options.region);
+      return this.provider.request('S3', 'putBucketNotificationConfiguration', cfg, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`);
     });
   }
 
@@ -340,7 +333,7 @@ class S3Deploy {
     if (this.functionPolicies[cfg.FunctionName]) {
       existingPolicyPromise = Promise.resolve(this.functionPolicies[cfg.FunctionName]);
     } else {
-      existingPolicyPromise = this.provider.request('Lambda', 'getPolicy', { FunctionName: cfg.FunctionName }, this.options.stage, this.options.region)
+      existingPolicyPromise = this.provider.request('Lambda', 'getPolicy', { FunctionName: cfg.FunctionName }, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`)
       .then((result) => {
         let policy = JSON.parse(result.Policy);
         this.functionPolicies[cfg.FunctionName] = policy;
@@ -360,7 +353,7 @@ class S3Deploy {
       let ourStatement = policy && policy.Statement.find((stmt) => stmt.Sid === cfg.StatementId);
       if (ourStatement) {
         //delete the statement before adding a new one
-        return this.provider.request('Lambda', 'removePermission', { FunctionName: cfg.FunctionName, StatementId: cfg.StatementId }, this.options.stage, this.options.region);
+        return this.provider.request('Lambda', 'removePermission', { FunctionName: cfg.FunctionName, StatementId: cfg.StatementId }, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`);
       } else {
         //just resolve
         return Promise.resolve();
@@ -376,7 +369,7 @@ class S3Deploy {
     })
     .then(() => {
       //put the new policy
-      return this.provider.request('Lambda', 'addPermission', cfg, this.options.stage, this.options.region);
+      return this.provider.request('Lambda', 'addPermission', cfg, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`);
     });
   }
 
@@ -391,7 +384,7 @@ class S3Deploy {
 
     return Promise.all(bucketNotifications.map((cfg) => {
 
-      return this.provider.request('S3', 'getBucketNotificationConfiguration', { Bucket: cfg.Bucket }, this.options.stage, this.options.region)
+      return this.provider.request('S3', 'getBucketNotificationConfiguration', { Bucket: cfg.Bucket }, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`)
           .then((bucketConfig) => {
 
             let notificationConfig = {remove: false, params: {}};
@@ -422,7 +415,7 @@ class S3Deploy {
               return;
             }
 
-            return this.provider.request('S3', 'putBucketNotificationConfiguration', cfg.params, this.options.stage, this.options.region);
+            return this.provider.request('S3', 'putBucketNotificationConfiguration', cfg.params, `${this.serverless.service.provider.stage}`, `${this.serverless.service.provider.region}`);
             
           });
 

--- a/index.js
+++ b/index.js
@@ -291,14 +291,14 @@ class S3Deploy {
       
       // This removes entries that are no longer in your notifications config
       var deleteIndexes = []
-      for (var i = 0; i < cfg.NotificationConfiguration.LambdaFunctionConfigurations.length; i++) {
+      for (var j = 0; j < bucketConfig.LambdaFunctionConfigurations.length; j++) {
         found = false;
-        for (var j = 0; j < bucketConfig.LambdaFunctionConfigurations.length; j++) {
+        for (var i = 0; i < cfg.NotificationConfiguration.LambdaFunctionConfigurations.length; i++) {
           if (bucketConfig['LambdaFunctionConfigurations'][j]['Id'] == cfg.NotificationConfiguration.LambdaFunctionConfigurations[i]['Id']) {
             found = true;
           }
-          if (!found) deleteIndexes.push(j)
         }
+        if (!found) deleteIndexes.push(j)
       }
       // Have to do this separately, can't do it within' the for loop above or the for loop fails
       deleteIndexes.forEach(function (index) {


### PR DESCRIPTION
Fixes #36 

Making serverless-external-s3-event able to support multiple existingS3 definitions, and to properly add/remove old items that we added from the notifications queue, but not touch existing notifications.  There was an additional "fix" put in this merge that fixes when your stage or region is not a static value, but a "rendered" one, eg: `region: ${file(config_local.yml):region}`.  I think this is now standard practice and (should be) practically required to specify the region in your serverless.yml file, so we don't need cascading failover logic in the module.

Modified four things to make this possible...
- The StatementId of the bucket configuration is now generated from a hash of the bucket events and rules/filters
- The Id of the lambda function configuration is now generated from a hash of the bucket events and filter
- The s3EventApi logic has its code updated to either update an existing config or remove old/outdated configs.  It also has some logic inside to not remove other notifications that were not deployed by this stack.
- The getFunctionArnFromDeployedStack function which contains the output that you see when serverless deploys, now contains the prefix and suffixes, if present.  For example...

```
serverless s3deploy
Serverless: Attaching sampleS3Project-dev-functionName to my-sample-lambda-bucket s3:ObjectCreated:* for prefix: media/ suffix: .jpg ...
Serverless: Done.
```

And yes, my node-fu isn't strong, but this is functional and well thought through and tested quite a bit.  Rewrite at your own desire/request/peril.  :)

Enjoy.  :)