### PR TITLE
ensure id is not longer than 100 chars

### DIFF
--- a/Permissions.js
+++ b/Permissions.js
@@ -7,7 +7,9 @@ class LambdaPermissions {
   }
 
   getId(functionName,bucketName) {
-    return `exS3-v2-${functionName}-${bucketName.replace(/[\.\:\*]/g,'')}`;
+    const id = `exS3-v2-${functionName}-${bucketName.replace(/[\.\:\*]/g,'')}`;
+    if (id.length < 100) { return id }
+    return id.substring(0,68) + require('crypto').createHash('md5').update(id).digest("hex")
   }
 
   createPolicy(functionName,bucketName,passthrough){


### PR DESCRIPTION
If the id is longer than 100 chars one gets the error
`1 validation error detected: Value 'exS3-v2-xxx' at 'statementId' failed to satisfy constraint: Member must have length less than or equal to 100`