### PR TITLE
Fix incorrect events behavior

### DIFF
--- a/S3.js
+++ b/S3.js
@@ -10,7 +10,7 @@ class S3 {
   }
 
   getId(event) {
-    const eventTypes = event.existingS3.event || ['s3:ObjectCreated:*'];
+    const eventTypes = event.existingS3.events || ['s3:ObjectCreated:*'];
     const rules      = event.existingS3.rules ? event.existingS3.rules.sort( (a,b) => Object.keys(a) - Object.keys(b) ) : [];
     const md5Data    = `${event.arn}_${eventTypes.join('OR').replace(/[\.\:\*]/g,'')}_${rules.map(rule => JSON.stringify(rule)).join('-')}`;
     const md5        = crypto.createHash('md5').update(md5Data).digest("hex");


### PR DESCRIPTION
existingS3's `events` did not work correctly.
I've got the same error as #54 when I Did like this.

```
functions:
  someFunction:
    handler: index.handler
    events:
      - existingS3:
          bucket: BUCKET_NAME
          event: s3:ObjectCreated:*
          rules:
            - prefix: images/
            - suffix: .jpg
```

And found out events property may be ignored and event property should be a list. 
If I want to set `existingS3` events with current code, I have to set `event` list not `events` list like below.

```
functions:
  someFunction:
    handler: index.handler
    events:
      - existingS3:
          bucket: BUCKET_NAME
          event:
            - s3:ObjectCreated:*
          rules:
            - prefix: images/
            - suffix: .jpg
``` 

So I fixed events to move correctly anyway.

Thanks.