### PR TITLE
Using the alias option as the qualifier for the lambda functions

### DIFF
--- a/Permissions.js
+++ b/Permissions.js
@@ -2,7 +2,8 @@
 
 class LambdaPermissions {
 
-  constructor(provider) {
+  constructor(options, provider) {
+    this.options = options;
     this.provider = provider;
   }
 
@@ -19,13 +20,20 @@ class LambdaPermissions {
       Principal: 's3.amazonaws.com',
       StatementId: this.getId(functionName,bucketName),
       SourceArn: `arn:aws:s3:::${bucketName}`
+    };
+    if (this.options.alias) {
+      payload['Qualifier'] = this.options.alias;
     }
     return this.provider.request('Lambda', 'addPermission', payload)
       .then( () => this.getPolicy(functionName, passthrough) )
   }
 
   getPolicy(functionName,passthrough) {
-    return this.provider.request('Lambda', 'getPolicy', { FunctionName: functionName })
+    const payload = {FunctionName: functionName};
+    if (this.options.alias) {
+      payload['Qualifier'] = this.options.alias;
+    }
+    return this.provider.request('Lambda', 'getPolicy', payload)
       .then( results => Object.assign({},{ statement: this.getStatement(this.asJson(results.Policy),passthrough), passthrough }) )
       .catch( error => Object.assign({}, { error:error.message, passthrough } ) );
   }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Done.
 
 ```
 
+**Command line options**
+
+* `--alias`: Use this option to specify the lambda function's alias to be set as the event handler. This is optional and if omitted, the lambda function without a qualifier will be used (the `$LATEST` version). Here's an example on how to use it:
+
+```
+> sls deploy --stage dev --alias dev
+> sls s3deploy --stage dev --alias dev
+``` 
+
 # I haz an errawr
 
 The only one I see, and quite regularly during my testing, is a result of having the wrong bucket name configured in the serverless.yml, either in the IAM configuration providing permissions or in the function definition where I'm attaching the event. Make sure your bucket names are right.

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const Permissions = require('./Permissions');
 const S3          = require('./S3');
 const Transformer = require('./Transformer');
-const BucketConfig = require('./BucketConfig')
+const BucketConfig = require('./BucketConfig');
 
 
 class S3Deploy {
@@ -14,7 +14,7 @@ class S3Deploy {
     this.options           = options;
     this.provider          = this.serverless.getProvider('aws');
     this.s3Facade          = new S3(this.serverless,this.options,this.provider);
-    this.lambdaPermissions = new Permissions.Lambda(this.provider);
+    this.lambdaPermissions = new Permissions.Lambda(this.options, this.provider);
     this.transformer       = new Transformer(this.lambdaPermissions);
     this.commands          = {
       s3deploy: {


### PR DESCRIPTION
This pull request helps with supporting qualifiers/aliases for lambda functions. While deploying, the user can specify `--alias dev` and the `dev` alias of the lambda function will be used as the event handler on the S3 bucket.

The code will look for `alias` option and if present, it will use it to load/create the policy for lambda functions. If it is not present, it will continue as it did before. The change to `index.js` is made only so the `options` are passed to the `Permissions.js`.