### PR TITLE
Fix: fix SourceArn error when create policy(aws china)  

### DIFF
--- a/Permissions.js
+++ b/Permissions.js
@@ -14,12 +14,13 @@ class LambdaPermissions {
   }
 
   createPolicy(functionName,bucketName,passthrough){
+    let region = (this.provider.sdk && this.provider.sdk.config && this.provider.sdk.config.region) || undefined;
     const payload = {
       Action: "lambda:InvokeFunction",
       FunctionName: functionName,
       Principal: 's3.amazonaws.com',
       StatementId: this.getId(functionName,bucketName),
-      SourceArn: `arn:aws:s3:::${bucketName}`
+      SourceArn: `arn:${(region && /^cn\-/.test(region)) ? 'aws-cn' : 'aws'}:s3:::${bucketName}`
     };
     if (this.options.alias) {
       payload['Qualifier'] = this.options.alias;

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ class S3Deploy {
     this.serverless        = serverless;
     this.options           = options;
     this.provider          = this.serverless.getProvider('aws');
+    if (!(this.provider.sdk && this.provider.sdk.config && this.provider.sdk.config.region)) {
+      this.provider.sdk.config.region = this.serverless.service.provider.region;
+    }
     this.s3Facade          = new S3(this.serverless,this.options,this.provider);
     this.lambdaPermissions = new Permissions.Lambda(this.options, this.provider);
     this.transformer       = new Transformer(this.lambdaPermissions);


### PR DESCRIPTION
Fix: fix SourceArn error when create policy(aws china)
Fix: fix some times `provider.sdk.config.region` is undefined