### PR TITLE
feat: keep notifications to other aliases considering them not relevant

### DIFF
--- a/BucketConfig.js
+++ b/BucketConfig.js
@@ -3,8 +3,9 @@
 const S3 = require('./S3.js')
 
 class BucketConfig {
-  constructor(config, serverless, provider) {
+  constructor(config, serverless, options) {
     this.config = config
+    this.options = options;
     this.s3 = new S3()
     this.serverless = serverless
     if (serverless != undefined){
@@ -92,7 +93,8 @@ class BucketConfig {
   }
 
   relevantARN(arn) {
-    let re = new RegExp(this.service + "-" + this.stage, 'gi')
+    const aliasPart = (this.options && this.options.alias) ? `.*:${this.options.alias}` : '';
+    let re = new RegExp(this.service + "-" + this.stage + aliasPart, 'gi')
     return arn.match(re)
   }
 }

--- a/Permissions.js
+++ b/Permissions.js
@@ -8,7 +8,8 @@ class LambdaPermissions {
   }
 
   getId(functionName,bucketName) {
-    const id = `exS3-v2-${functionName}-${bucketName.replace(/[\.\:\*]/g,'')}`;
+    const aliasName = this.options.alias ? `-${this.options.alias}` : '';
+    const id = `exS3-v2-${functionName}${aliasName}-${bucketName.replace(/[\.\:\*]/g,'')}`;
     if (id.length < 100) { return id }
     return id.substring(0,68) + require('crypto').createHash('md5').update(id).digest("hex")
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-existing-s3",
-  "version": "2.2.2",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-existing-s3",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Attach Lambda events to an existing S3 bucket, for Serverless.com 1.11.0+.",
   "main": "index.js",
   "homepage": "https://github.com/matt-filion/serverless-external-s3-event",

--- a/spec/BucketConfig_spec.js
+++ b/spec/BucketConfig_spec.js
@@ -17,6 +17,14 @@ describe('BucketConfig', function() {
     })
   })
 
+  describe('addNewNotificationsWithAliases', function() {
+    it('adds notifications to aliased lambdas existing only in the file to the config', function() {
+      let bucketConfig = new BucketConfig(notifications.addedWithAliases)
+      bucketConfig.addNewNotifications(configurations.addedWithAliases)
+      expect(bucketConfig.getConfig()).to.deep.eq(notificationsWithConfigurations.addedWithAliases)
+    })
+  })
+
   describe('removeObsoleteNotifications', function() {
     it('removes relevant notifications not in the config file', function() {
       let bucketConfig = new BucketConfig(notifications.obsolete, {
@@ -27,6 +35,19 @@ describe('BucketConfig', function() {
       })
       bucketConfig.removeObsoleteNotifications(configurations.obsolete)
       expect(bucketConfig.getConfig()).to.deep.eq(notificationsWithConfigurations.obsolete)
+    })
+  })
+
+  describe('removeObsoleteNotificationsWithAliases', function() {
+    it('removes relevant notifications not in the config file, taking into account aliases', function() {
+      let bucketConfig = new BucketConfig(notifications.obsoleteWithAliases, {
+        "service": {
+          "getServiceObject": sinon.stub().returns({ "name": "serverless-test" }),
+          "provider": { "stage": "production" }
+        }
+      }, { alias: 'test_alias' })
+      bucketConfig.removeObsoleteNotifications(configurations.obsoleteWithAliases)
+      expect(bucketConfig.getConfig()).to.deep.eq(notificationsWithConfigurations.obsoleteWithAliases)
     })
   })
 })

--- a/spec/fixtures/configurations.json
+++ b/spec/fixtures/configurations.json
@@ -23,7 +23,31 @@
       }
     ]
   },
-    "obsolete": {
+  "addedWithAliases": {
+    "name": "s3-serverless-test",
+    "events": [
+      {
+        "existingS3": {
+          "bucket": "s3-serverless-test",
+          "events": [
+            "s3:ObjectCreated:*"
+          ],
+          "rules": [
+            {
+              "Prefix": "automated/"
+            },
+            {
+              "Suffix": ".txt"
+            }
+          ]
+        },
+        "handler": "handler.handle",
+        "name": "serverless-test-production-serverless-deploy-test",
+        "arn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-deploy-test:test_alias"
+      }
+    ]
+  },
+  "obsolete": {
     "name": "s3-serverless-test",
     "events": [
       {
@@ -44,6 +68,30 @@
         "handler": "handler.handle",
         "name": "serverless-test-production-serverless-second-test",
         "arn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-second-test"
+      }
+    ]
+  },
+  "obsoleteWithAliases": {
+    "name": "s3-serverless-test",
+    "events": [
+      {
+        "existingS3": {
+          "bucket": "s3-serverless-test",
+          "events": [
+            "s3:ObjectCreated:*"
+          ],
+          "rules": [
+            {
+              "Prefix": "automated/"
+            },
+            {
+              "Suffix": ".txt"
+            }
+          ]
+        },
+        "handler": "handler.handle",
+        "name": "serverless-test-production-serverless-second-test",
+        "arn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-second-test:test_alias"
       }
     ]
   }

--- a/spec/fixtures/notifications.json
+++ b/spec/fixtures/notifications.json
@@ -50,7 +50,58 @@
       ]
     }
   },
-    "obsolete": {
+  "addedWithAliases": {
+    "bucket": "s3-serverless-test",
+    "results": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaFunctionConfigurations": [
+        {
+          "Id": "exS3-v2--a1a71fe0a56f35d8a5514afbe33a187d",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-deploy-test:test_alias",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".gz"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "Id": "exS3-v2--12e4385ca3170e0460cad7afa8c9f8ed",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test2-production-serverless-second-test:test_alias",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".txt"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "obsolete": {
     "bucket": "s3-serverless-test",
     "results": {
       "TopicConfigurations": [],
@@ -80,6 +131,57 @@
         {
           "Id": "exS3-v2--9ffc698932e20da8219cfc206538963d",
           "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-second-test",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".txt"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "obsoleteWithAliases": {
+    "bucket": "s3-serverless-test",
+    "results": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaFunctionConfigurations": [
+        {
+          "Id": "exS3-v2--a1a71fe0a56f35d8a5514afbe33a187d",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-deploy-test:test_alias",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".gz"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "Id": "exS3-v2--a1711f05b474ec45be127a5a0ca5dc1a",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-second-test:test_alias",
           "Events": [
             "s3:ObjectCreated:*"
           ],

--- a/spec/fixtures/notifications_with_configurations.json
+++ b/spec/fixtures/notifications_with_configurations.json
@@ -71,6 +71,78 @@
       ]
     }
   },
+  "addedWithAliases": {
+    "bucket": "s3-serverless-test",
+    "results": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaFunctionConfigurations": [
+        {
+          "Id": "exS3-v2--a1a71fe0a56f35d8a5514afbe33a187d",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-deploy-test:test_alias",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".gz"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "Id": "exS3-v2--12e4385ca3170e0460cad7afa8c9f8ed",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test2-production-serverless-second-test:test_alias",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".txt"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "Id": "exS3-v2--27a754a85801dbc9434e1b64597d45c5",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-deploy-test:test_alias",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".txt"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
   "obsolete": {
     "bucket": "s3-serverless-test",
     "results": {
@@ -80,6 +152,36 @@
         {
           "Id": "exS3-v2--9ffc698932e20da8219cfc206538963d",
           "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-second-test",
+          "Events": [
+            "s3:ObjectCreated:*"
+          ],
+          "Filter": {
+            "Key": {
+              "FilterRules": [
+                {
+                  "Name": "Prefix",
+                  "Value": "automated/"
+                },
+                {
+                  "Name": "Suffix",
+                  "Value": ".txt"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "obsoleteWithAliases": {
+    "bucket": "s3-serverless-test",
+    "results": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaFunctionConfigurations": [
+        {
+          "Id": "exS3-v2--a1711f05b474ec45be127a5a0ca5dc1a",
+          "LambdaFunctionArn": "arn:aws:lambda:us-east-1:01234:function:serverless-test-production-serverless-second-test:test_alias",
           "Events": [
             "s3:ObjectCreated:*"
           ],


### PR DESCRIPTION
Thank you for this plugin, it's very usefull. I've tried to improve the recent support for aliases, keeping untouched the created notifications for other aliases of the same lambda when you update them.

The key is to consider the existing notifications for other aliases "not relevant" (as you are doing now with notifications created using mechanisms different than this plugin).

Moreover, I've added a couple of tests to support my PR, and I've increased the package.json version with a minor update. Of course feel free to change or comment what you consider.

HTH