### PR TITLE
fix: add this.options to BucketConfig, to provide it the alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ class S3Deploy {
 
           const existingS3Notifications = this.currentBucketNotifications.find( currentNotification => currentNotification.bucket === bucketConfigurationFromFile.name );
 
-          let bucketConfig = new BucketConfig(existingS3Notifications, this.serverless)
+          let bucketConfig = new BucketConfig(existingS3Notifications, this.serverless, this.options)
 
           bucketConfig.update(bucketConfigurationFromFile)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-existing-s3",
-  "version": "2.3.1",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-existing-s3",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Attach Lambda events to an existing S3 bucket, for Serverless.com 1.11.0+.",
   "main": "index.js",
   "homepage": "https://github.com/matt-filion/serverless-external-s3-event",


### PR DESCRIPTION
I forgot to modify the index.js to include the options in the creation of the BucketConfig.